### PR TITLE
Fix: Correct parameter name for AI summary API call

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -114,7 +114,8 @@ class ApiService {
   }
 
   Future<String> fetchSummary(String owner, String repo) async {
-    final response = await http.get(Uri.parse('$_baseUrl/summarize?owner=$owner&repo=$repo'));
+    // The 'owner' parameter in the request URL should be 'author' to match the backend API.
+    final response = await http.get(Uri.parse('$_baseUrl/summarize?author=$owner&repo=$repo'));
 
     if (response.statusCode == 200) {
       Map<String, dynamic> data = jsonDecode(utf8.decode(response.bodyBytes));


### PR DESCRIPTION
Changed the parameter key from 'owner' to 'author' in the `fetchSummary` method in `lib/services/api_service.dart` to match the backend API's expectation for a GET request.

The backend /api/summarize endpoint expects 'author' and 'repo' as query parameters. This change ensures the Flutter client sends the correct parameter name.