### PR TITLE
Feat: Redesign RepositoryCard, add Share & DeepWiki features

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -125,8 +125,8 @@ class _HomePageState extends State<HomePage> {
             showCheckmark: false, // Optional: to make it look more like tabs
             selectedColor: Theme.of(context).colorScheme.primary.withOpacity(0.8),
             labelStyle: TextStyle(
-              color: _selectedSince == since
-                  ? Theme.of(context).colorScheme.onPrimary
+              color: _selectedSince == since 
+                  ? Theme.of(context).colorScheme.onPrimary 
                   : Theme.of(context).colorScheme.onSurface,
             ),
           ),

--- a/lib/ui/screens/deepwiki_page.dart
+++ b/lib/ui/screens/deepwiki_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class DeepWikiPage extends StatefulWidget {
+  final String url;
+
+  const DeepWikiPage({super.key, required this.url});
+
+  @override
+  State<DeepWikiPage> createState() => _DeepWikiPageState();
+}
+
+class _DeepWikiPageState extends State<DeepWikiPage> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      // Optional: You can set a NavigationDelegate for more control
+      // ..setNavigationDelegate(
+      //   NavigationDelegate(
+      //     onProgress: (int progress) {
+      //       // Update loading bar progress.
+      //     },
+      //     onPageStarted: (String url) {},
+      //     onPageFinished: (String url) {},
+      //     onWebResourceError: (WebResourceError error) {},
+      //     onNavigationRequest: (NavigationRequest request) {
+      //       // Example: Prevent navigation to other domains
+      //       // if (!request.url.startsWith(widget.url)) { // Be careful with this logic
+      //       //   return NavigationDecision.prevent;
+      //       // }
+      //       return NavigationDecision.navigate;
+      //     },
+      //   ),
+      // )
+      ..loadRequest(Uri.parse(widget.url));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('DeepWiki View'),
+        // Example: Add a loading indicator in the AppBar if desired
+        // bottom: _isLoadingPage ? PreferredSize(
+        //   preferredSize: Size.fromHeight(4.0),
+        //   child: LinearProgressIndicator(),
+        // ) : null,
+      ),
+      body: WebViewWidget(
+        controller: _controller,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   http: ^1.2.1
   flutter_material_symbols: ^0.0.4
+  webview_flutter: ^4.13.0
+  share_plus: ^11.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This commit introduces a significant redesign of the RepositoryCard UI and implements Share and in-app DeepWiki functionality.

Key changes:

- **RepositoryCard Redesign:**
    - Changed card structure to have a base blurred avatar background with a clear content area on top.
    - The clear content area now displays a non-blurred avatar, repository title, author, description, and stats, improving readability and visual hierarchy.
    - Blur sigma for the background is currently set to 6.0.
    - AI Summary section and action buttons (Share, DeepWiki) are integrated into the new layout.

- **Share Button Functionality:**
    - Added `share_plus` package.
    - Implemented the Share button to use `Share.share()` for sharing the repository's GitHub URL.

- **DeepWiki Functionality (In-App WebView):**
    - Added `webview_flutter` package.
    - Created a new `DeepWikiPage` screen that uses `WebViewWidget` to display web content.
    - Implemented the DeepWiki button on `RepositoryCard` to:
        - Transform the GitHub repository URL to a `deepwiki.com` URL.
        - Navigate to the `DeepWikiPage` to show the content in-app.

- **Plugin Setup:**
    - `webview_flutter` and `share_plus` added to `pubspec.yaml`.